### PR TITLE
Add Faker gem for generating fake data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "bootsnap", require: false
 gem "devise", "~> 4.9", ">= 4.9.3"
 gem "dotenv", "~> 3.1", ">= 3.1.7"
+gem "faker", "~> 3.4", ">= 3.4.2"
 gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -355,6 +357,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9, >= 4.9.3)
   dotenv (~> 3.1, >= 3.1.7)
+  faker (~> 3.4, >= 3.4.2)
   importmap-rails
   jbuilder
   kamal

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,22 +1,12 @@
-Property.create!({
-  name: "The White House",
-  headline: "The White House",
-  description: "The White House is the official residence and workplace of the president of the United States. It is located at 1600 Pennsylvania Avenue NW in Washington, D.C., and has been the residence of every U.S. president since John Adams in 1800.",
-  address_1: "1600 Pennsylvania Avenue NW",
-  address_2: "Washington, DC 20500, USA",
-  city: "Washington",
-  state: "DC",
-  country: "USA"
-
-})
-
-Property.create!({
-  name: "Buckingham Palace",
-  headline: "Buckingham Palace",
-  description: "Buckingham Palace is the London residence and administrative headquarters of the monarch of the United Kingdom. Located in the City of Westminster, the palace is often at the centre of state occasions and royal hospitality.",
-  address_1: "Westminster",
-  address_2: "London SW1A 1AA, UK",
-  city: "London",
-  state: "England",
-  country: "UK"
-})
+20.times do
+  Property.create!({
+    name: Faker::Company.name,
+    headline: Faker::Company.catch_phrase,
+    description: Faker::Company.bs,
+    address_1: Faker::Address.street_address,
+    address_2: Faker::Address.secondary_address,
+    city: Faker::Address.city,
+    state: Faker::Address.state,
+    country: Faker::Address.country
+  })
+end


### PR DESCRIPTION
# Add Faker Gem and Dummy Data

## Description
This MR adds the Faker gem to the project for generating fake data during development and testing. It also includes the creation of dummy place names and descriptions using the Faker gem.

## Changes
- Added Faker gem to the `Gemfile`.
- Installed the gem using `bundle install`.
- Created dummy data for place names and descriptions using Faker.

### Example Dummy Data
Here’s an example of the dummy data generated using Faker:

```ruby
place_name = Faker::Address.city
description = Faker::Company.bs